### PR TITLE
Issue #204: Windows: Fixed system.disk.io_time and system.disk.operation_time

### DIFF
--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -33,7 +33,7 @@ monitors:
             column: 1
             subSeparators: ","
             subColumn: 2
-          # Convert 100ns to s 
+          # Convert 100ns to s
           - type: divide
             column: 2
             value: 10000000
@@ -235,10 +235,23 @@ monitors:
               PercentDiskReadTime,
               PercentDiskWriteTime
             FROM Win32_PerfRawData_PerfDisk_PhysicalDisk WHERE NAME != '_Total'
+          computes:
+          # *DiskTime values in Win32_PerfRawData_PerfDisk_PhysicalDisk are expressed in 100ns
+          # We need to divide the values by 10,000,000 to convert to seconds
+          - type: divide
+            column: 6
+            value: 10000000
+          - type: divide
+            column: 7
+            value: 10000000
+          - type: divide
+            column: 8
+            value: 10000000
       mapping:
         source: ${source::physicalDiskInformation}
         attributes:
           id: $1
+          system.device: $1
         metrics:
           system.disk.io{disk.io.direction="read"}: $2
           system.disk.io{disk.io.direction="write"}: $3

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -234,7 +234,7 @@ monitors:
               PercentDiskTime,
               PercentDiskReadTime,
               PercentDiskWriteTime,
-              Frequency_PerfTime,
+              Frequency_PerfTime
             FROM Win32_PerfRawData_PerfDisk_PhysicalDisk WHERE NAME != '_Total'
           computes:
           # *DiskTime values in Win32_PerfRawData_PerfDisk_PhysicalDisk are expressed in fraction of seconds

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -233,20 +233,22 @@ monitors:
               DiskWritesPersec,
               PercentDiskTime,
               PercentDiskReadTime,
-              PercentDiskWriteTime
+              PercentDiskWriteTime,
+              Frequency_PerfTime,
             FROM Win32_PerfRawData_PerfDisk_PhysicalDisk WHERE NAME != '_Total'
           computes:
-          # *DiskTime values in Win32_PerfRawData_PerfDisk_PhysicalDisk are expressed in 100ns
-          # We need to divide the values by 10,000,000 to convert to seconds
+          # *DiskTime values in Win32_PerfRawData_PerfDisk_PhysicalDisk are expressed in fraction of seconds
+          # Fraction is defined in Frequency_PerfTime
+          # We need to divide the values by Frequency_PerfTime to convert to seconds
           - type: divide
-            column: 6
-            value: 10000000
+            column: 6 # PercentDiskTime
+            value: $9 # Frequency_PerfTime
           - type: divide
-            column: 7
-            value: 10000000
+            column: 7 # PercentDiskReadTime
+            value: $9 # Frequency_PerfTime
           - type: divide
-            column: 8
-            value: 10000000
+            column: 8 # PercentDiskWriteTime
+            value: $9 # Frequency_PerfTime
       mapping:
         source: ${source::physicalDiskInformation}
         attributes:


### PR DESCRIPTION
In the `Windows` connector, convert `system.disk.io_time` and `system.disk.operation_time` from 100ns to seconds.

Also added `system.device` required attribute.