### PR TITLE
Rename metric db.server.active_connections to db.server.current_connections in MySQL connector

### DIFF
--- a/src/main/connector/database/MySQL/MySQL.yaml
+++ b/src/main/connector/database/MySQL/MySQL.yaml
@@ -172,7 +172,7 @@ monitors:
           db.server.io{db.io.direction="write"}: $6
           db.server.io{db.io.direction="read"}: $7
           db.server.connections{db.connection.state="success"}: $8
-          db.server.active_connections: $9
+          db.server.current_connections{db.connection.state="active"}: $9
           db.server.queries{db.query.state="failed", error.type="set_timeout_failed"}: $10
           db.server.queries{db.query.state="failed", error.type="timeout"}: $11
           db.server.page.size{db.mysql.engine="innodb"}: $12

--- a/src/main/connector/semconv/Database.yaml
+++ b/src/main/connector/semconv/Database.yaml
@@ -3,7 +3,7 @@ metrics:
     description: The number of connection attempts (successful or not) to the database.
     type: Counter
     unit: "{connection}"
-  db.server.active_connections:
+  db.server.current_connections:
     description: The number of client connections to the database.
     type: UpDownCounter
     unit: "{connection}"


### PR DESCRIPTION
Updated MySQL.yaml and Database.yaml

#### Tested : 
![image](https://github.com/user-attachments/assets/ebbeaadd-089e-46bd-b592-5ad1f560ca4e)
