### PR TITLE
Issue #224: Linux, Windows: Collect system.network.bandwidth.limit

### DIFF
--- a/src/main/connector/semconv/System.yaml
+++ b/src/main/connector/semconv/System.yaml
@@ -107,6 +107,10 @@ metrics:
     description: Network I/O count
     type: Counter
     unit: By
+  system.network.bandwidth.limit:
+    description: Current link speed of the network interface
+    type: UpDownCounter
+    unit: By
   system.network.connections:
     description: Count of network connections
     type: UpDownCounter

--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -139,28 +139,60 @@ monitors:
   network:
     simple:
       sources:
-        networkInformation:
-          # Interface;MTU;State;RX_bytes;RX_packets;RX_errors;RX_dropped;RX_missed;RX_mcast;TX_bytes;TX_packets;TX_errors;TX_dropped;TX_carrier;TX_collsns";
+        # Use the ip command to get network interface information
+        ipLink:
+          # Interface;MTU;State;RX_bytes;RX_packets;RX_errors;RX_dropped;RX_missed;RX_mcast;TX_bytes;TX_packets;TX_errors;TX_dropped;TX_carrier;TX_collsns;
           type: commandLine
           commandLine: /usr/sbin/ip -s link
           computes:
           - type: awk
             script: ${file::network.awk}
-        interfaceInformation:
+
+        # Use the sysfs filesystem to filter out virtual interfaces
+        sysClassNet:
+          # Interface;
           type: commandLine
           commandLine: ls -l /sys/class/net
           computes:
           - type: awk
             script: |
               $0 !~ /virtual/ && $0 !~ /total/ {print $9}
-        networkPhysicalInterface:
+
+        # Use the sysfs filesystem to get the link speed of each interface
+        linkSpeed:
+          # Interface;SpeedMbps
+          # Note: The speed is in Mbps, so we need to convert it to bytes per second
+          type: commandLine
+          commandLine: |
+            for iface in `ls /sys/class/net`; do
+              speed=$(cat /sys/class/net/$iface/speed 2>/dev/null || echo 0)
+              echo "$iface;$speed"
+            done
+          computes:
+          # Convert speed from Mbps to bytes per second
+          # Interface;SpeedBytesPerSecond
+          - type: multiply
+            value: 125000
+            column: 2
+
+        # Now join the three sources together
+        networkTempJoin:
+          # Interface;MTU;State;RX_bytes;RX_packets;RX_errors;RX_dropped;RX_missed;RX_mcast;TX_bytes;TX_packets;TX_errors;TX_dropped;TX_carrier;TX_collsns;Interface;
           type: tableJoin
-          leftTable: ${source::networkInformation}
-          rightTable: ${source::interfaceInformation}
+          leftTable: ${source::ipLink}
+          rightTable: ${source::sysClassNet}
           leftKeyColumn: 1
           rightKeyColumn: 1
+        networkAll:
+          # Interface;MTU;State;RX_bytes;RX_packets;RX_errors;RX_dropped;RX_missed;RX_mcast;TX_bytes;TX_packets;TX_errors;TX_dropped;TX_carrier;TX_collsns;Interface;Interface;SpeedBytesPerSecond
+          type: tableJoin
+          leftTable: ${source::networkTempJoin}
+          rightTable: ${source::linkSpeed}
+          leftKeyColumn: 1
+          rightKeyColumn: 1
+
       mapping:
-        source: ${source::networkPhysicalInterface}
+        source: ${source::networkAll}
         attributes:
           id: $1
           network.interface.name: $1
@@ -173,6 +205,7 @@ monitors:
           system.network.errors{network.io.direction="receive"}: $6
           system.network.io{network.io.direction="transmit"}: $10
           system.network.io{network.io.direction="receive"}: $4
+          system.network.bandwidth.limit: $18
 
   # Physical disks
   physical_disk:

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -247,8 +247,8 @@ monitors:
   network:
     simple:
       sources:
-        # Name;PacketsOutboundDiscarded;PacketsReceivedDiscarded;PacketsSentPersec;PacketsReceivedPersec;PacketsOutboundErrors;PacketsReceivedErrors
-        networkInformation:
+        # Name;PacketsOutboundDiscarded;PacketsReceivedDiscarded;PacketsSentPersec;PacketsReceivedPersec;PacketsOutboundErrors;PacketsReceivedErrors;BytesSentPerSec;BytesReceivedPerSec;BandwidthBps
+        Win32_PerfRawData_Tcpip_NetworkInterface:
           type: wmi
           namespace: root\CIMv2
           query: >
@@ -260,10 +260,18 @@ monitors:
               PacketsOutboundErrors,
               PacketsReceivedErrors,
               BytesSentPerSec,
-              BytesReceivedPerSec
+              BytesReceivedPerSec,
+              CurrentBandwidth
             FROM Win32_PerfRawData_Tcpip_NetworkInterface
+          computes:
+            # Converting Bandwidth from bits to bytes
+            # Name;PacketsOutboundDiscarded;PacketsReceivedDiscarded;PacketsSentPersec;PacketsReceivedPersec;PacketsOutboundErrors;PacketsReceivedErrors;BytesSentPerSec;BytesReceivedPerSec;BandwidthBytes
+            - type: divide
+              column: 10
+              value: 8
+
       mapping:
-        source: ${source::networkInformation}
+        source: ${source::Win32_PerfRawData_Tcpip_NetworkInterface}
         attributes:
           id: $1
           network.interface.name: $1
@@ -276,6 +284,7 @@ monitors:
           system.network.errors{network.io.direction="receive"}: $7
           system.network.io{network.io.direction="transmit"}: $8
           system.network.io{network.io.direction="receive"}: $9
+          system.network.bandwidth.limit: $10
 
   # Physical disk metrics
   physical_disk:


### PR DESCRIPTION
Tested on Linux:

![image](https://github.com/user-attachments/assets/206a4aaf-fbeb-40f7-a14f-1fb656fd78a1)

Tested on Windows:

![image](https://github.com/user-attachments/assets/e2475dec-a057-4c16-8854-4b7c90a783e4)

> **Note**
> `system.network.bandwidth.utilization` is not calculated as it would need to leverage IO rates and it's more proper to calculate at query time based on absolute counters.