### PR TITLE
Issue #250: Updated unit for hw.network.dropped to {packets}

### DIFF
--- a/src/main/connector/semconv/Hardware.yaml
+++ b/src/main/connector/semconv/Hardware.yaml
@@ -229,7 +229,7 @@ metrics:
   hw.network.dropped:
     description: The number of packets which were chosen to be discarded even though no errors had been detected.
     type: Counter
-    unit: "{packet}"
+    unit: "{packets}"
 
   hw.other_device.uses:
     description: Number of times the device has been used.


### PR DESCRIPTION
This pull request includes a minor correction to the `Hardware.yaml` file in the `semconv` connector. The change updates the unit of measurement for the `hw.network.dropped` metric from `{packet}` to `{packets}` to ensure proper pluralization.