### PR TITLE
MariaDB : translation table fails with NULL values on standalone DB

### DIFF
--- a/src/main/connector/database/MariaDB/MariaDB.yaml
+++ b/src/main/connector/database/MariaDB/MariaDB.yaml
@@ -211,8 +211,8 @@ monitors:
             -- Galera / wsrep
               MAX(CASE WHEN VARIABLE_NAME = 'wsrep_cluster_size' THEN VARIABLE_VALUE END) AS wsrep_cluster_size, -- $118
               COALESCE(MAX(CASE WHEN VARIABLE_NAME = 'wsrep_cluster_status' THEN VARIABLE_VALUE END),'not_applicable') AS wsrep_cluster_status, -- $119
-              COALESCE(MAX(CASE WHEN VARIABLE_NAME='wsrep_ready' THEN IF(VARIABLE_VALUE='ON',1,0) END), 0) AS wsrep_ready, -- $120
-              COALESCE(MAX(CASE WHEN VARIABLE_NAME='wsrep_connected' THEN IF(VARIABLE_VALUE='ON',1,0) END), 0) AS wsrep_connected, -- $121
+              COALESCE(MAX(CASE WHEN VARIABLE_NAME='wsrep_ready' THEN IF(VARIABLE_VALUE='ON',1,0) END), -1) AS wsrep_ready, -- $120
+              COALESCE(MAX(CASE WHEN VARIABLE_NAME='wsrep_connected' THEN IF(VARIABLE_VALUE='ON',1,0) END), -1) AS wsrep_connected, -- $121
               MAX(CASE WHEN VARIABLE_NAME = 'wsrep_flow_control_paused' THEN VARIABLE_VALUE END) AS wsrep_flow_control_paused, -- $122
               MAX(CASE WHEN VARIABLE_NAME = 'wsrep_local_recv_queue_avg' THEN VARIABLE_VALUE END) AS wsrep_local_recv_queue_avg, -- $123
               MAX(CASE WHEN VARIABLE_NAME = 'wsrep_local_send_queue_avg' THEN VARIABLE_VALUE END) AS wsrep_local_send_queue_avg, -- $124
@@ -526,6 +526,7 @@ translations:
   OnOffStatusTranslationTable:
     "1": on
     "0": off
+    "-1": unknown
     Default: unknown
 
 


### PR DESCRIPTION
* Update MariaDB.yaml 

### Tested 

<img width="1913" height="865" alt="image" src="https://github.com/user-attachments/assets/b995fa41-6c6d-4125-b382-b96ab65a10f6" />
