### PR TITLE
Issue #345: Refactor and align database metrics naming

### DIFF
--- a/src/main/connector/database/PostgreSQL/PostgreSQL.yaml
+++ b/src/main/connector/database/PostgreSQL/PostgreSQL.yaml
@@ -188,7 +188,7 @@ monitors:
           db.namespace: $1
           db.version: $2
         metrics:
-          db.server.current_connections.limit: $3
+          db.server.connections.limit: $3
           db.server.uptime: $4
           db.server.connections: $5
           db.server.current_connections{db.connection.state="active"}: $6

--- a/src/main/connector/semconv/Database.yaml
+++ b/src/main/connector/semconv/Database.yaml
@@ -135,10 +135,6 @@ metrics:
     description: Total number of rollbacks in the database.
     type: Counter
     unit: "{rollback}"
-  db.server.current_connections.limit:
-    description: The maximum number of client connections allowed to the database.
-    type: Gauge
-    unit: "{connection}"
   db.server.cache.size:
     description: The size of the database cache.
     type: Gauge
@@ -178,7 +174,7 @@ metrics:
         - degraded
   db.server.connections.limit: 
     description: The maximum number of simultaneous client connections.
-    type: Counter
+    type: Gauge
     unit: "{connection}"
   db.server.table_cache.operations:
     description: Number of lookup operations performed on the table open cache.


### PR DESCRIPTION
* Rename PostgreSQL metric db.server.current.connections.limit to db.server.connections.limit