### PR TITLE
Issue #358 Fix triggering of WindowsIpmiTool and LinuxIpmiTool in Redfish connector

### DIFF
--- a/src/main/connector/hardware/Redfish/Redfish.yaml
+++ b/src/main/connector/hardware/Redfish/Redfish.yaml
@@ -14,6 +14,8 @@ connector:
     - OOB
     supersedes:
     - IpmiTool
+    - LinuxIpmiTool
+    - WindowsIpmiTool
     criteria:
     # Hardware Sentry v10.2.00+
     - type: productRequirements


### PR DESCRIPTION
 * Mark LinuxIpmiTool and WindowsIpmiTool as superseded connectors alongside IpmiTool in Redfish.yaml