### PR TITLE
Feature/migrate to jdk 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
   build:
     uses: metricshub/workflows/.github/workflows/maven-build.yml@v4
     with:
-      jdkVersion: "17"
+      jdkVersion: "25"
       debug: ${{ github.event_name == 'workflow_dispatch' && inputs.debug }}
       ssh: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,5 +12,5 @@ jobs:
   deploy:
     uses: metricshub/workflows/.github/workflows/maven-central-deploy.yml@v4
     with:
-      jdkVersion: "17"
+      jdkVersion: "25"
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
       releaseVersion: ${{ inputs.releaseVersion }}
       developmentVersion: ${{ inputs.developmentVersion }}
       autoRelease: false
-      jdkVersion: "17"
+      jdkVersion: "25"
     secrets: inherit

--- a/pmd.xml
+++ b/pmd.xml
@@ -64,7 +64,6 @@ under the License.
 	<rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
 	<rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary" />
 	<rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals" />
-	<rule ref="category/java/errorprone.xml/UselessOperationOnImmutable" />
 
 	<rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
 	<rule ref="category/java/multithreading.xml/DontCallThreadRun" />

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,7 @@
 	</developers>
 
 	<properties>
-		<!-- Java 17 -->
-		<maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.release>25</maven.compiler.release>
 		<metricshub-community.version>3.9.04</metricshub-community.version>
 		<!-- Reproducible Build -->
 		<!-- See https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
@@ -214,6 +213,38 @@
 						<groupId>org.sentrysoftware.maven</groupId>
 						<artifactId>maven-skin-tools</artifactId>
 						<version>1.7.00</version>
+						<!-- maven-skin-tools 1.7.00 brings GraalJS / Truffle 23.0.11,
+						     which calls sun.misc.Unsafe.ensureClassInitialized,
+						     a method removed in JDK 22 (JDK-8316160). Exclude the
+						     legacy GraalVM stack and replace it below with a
+						     JDK 25-compatible release. -->
+						<exclusions>
+							<exclusion>
+								<groupId>org.graalvm.js</groupId>
+								<artifactId>js</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.graalvm.js</groupId>
+								<artifactId>js-scriptengine</artifactId>
+							</exclusion>
+							<exclusion>
+								<groupId>org.graalvm.truffle</groupId>
+								<artifactId>truffle-api</artifactId>
+							</exclusion>
+						</exclusions>
+					</dependency>
+					<!-- Modern (JDK 25-compatible) GraalVM polyglot stack to feed
+					     IndexTool. Replaces the legacy org.graalvm.js:js artifacts. -->
+					<dependency>
+						<groupId>org.graalvm.polyglot</groupId>
+						<artifactId>polyglot</artifactId>
+						<version>24.2.2</version>
+					</dependency>
+					<dependency>
+						<groupId>org.graalvm.polyglot</groupId>
+						<artifactId>js</artifactId>
+						<version>24.2.2</version>
+						<type>pom</type>
 					</dependency>
 				</dependencies>
 				<executions>
@@ -282,6 +313,7 @@
 			<!-- pmd -->
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.28.0</version>
 				<configuration>
 					<linkXref>true</linkXref>
 					<sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
@@ -290,6 +322,11 @@
 					<rulesets>
 						<ruleset>pmd.xml</ruleset>
 					</rulesets>
+					<!-- The only Java sources in this repo are integration tests
+					     under src/it/java (added via build-helper-maven-plugin).
+					     Tell PMD to analyze test sources too so it has something
+					     to scan; otherwise it emits "No files to analyze". -->
+					<includeTests>true</includeTests>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
This pull request upgrades the project to Java 25 and updates related build and dependency configurations to ensure compatibility. It also updates the PMD plugin and its configuration, and removes a deprecated PMD rule. The most important changes are grouped below:

**Java Version Upgrade**

* Upgraded the Java version used in GitHub Actions workflows (`build.yml`, `deploy.yml`, `release.yml`) from 17 to 25 to align with the new project requirements. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L23-R23) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L15-R15) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-R26)
* Updated the `maven.compiler.release` property in `pom.xml` from 17 to 25 to ensure the project is compiled for Java 25.

**Dependency and Plugin Updates for Java 25 Compatibility**

* Modified the `maven-skin-tools` dependency in `pom.xml` to exclude legacy GraalVM artifacts incompatible with JDK 25, and added modern `org.graalvm.polyglot` dependencies as replacements.
* Updated the `maven-pmd-plugin` version to 3.28.0 and configured it to include test sources in its analysis, ensuring PMD has files to scan in the current project structure. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R316) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R325-R329)

**PMD Ruleset Maintenance**

* Removed the deprecated `UselessOperationOnImmutable` rule from `pmd.xml` to keep the PMD configuration up to date.